### PR TITLE
Updated returntype for autocompletion menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # SourcePawn Completions for SublimeText 3
 
-A Sublime Text 3 plugin that dynamically genenerates completions for SourcePawn.
+A Sublime Text 3 plugin that dynamically genenerates completions for SourcePawn.  
 
-Based on [sublime-sourcepawn](https://github.com/austinwagner/sublime-sourcepawn).
-Includes [watchdog python module](https://https://github.com/gorakhargosh/watchdog)
+Based on [sublime-sourcepawn](https://github.com/austinwagner/sublime-sourcepawn).  
+Includes [watchdog python module](https://https://github.com/gorakhargosh/watchdog)  
+  
+  
+<p><img src="https://i.imgur.com/Xzum7I8.png"></p>
 
 ## Installing
 

--- a/SPCompletions.py
+++ b/SPCompletions.py
@@ -379,7 +379,8 @@ def process_lines(line_reader, node) :
         (buffer, found_comment, brace_level) = read_string(buffer, found_comment, brace_level)
         if len(buffer) <= 0 :
             continue
-        if buffer.startswith('#pragma deprecated') :
+        # if buffer.startswith('#pragma deprecated') :
+        if re.search(r'^\s*#pragma deprecated') :
             buffer = read_line(line_reader)
             if buffer is not None and buffer.startswith('stock ') :
                 buffer = skip_brace_line(line_reader, buffer)
@@ -530,8 +531,6 @@ def get_full_function_string(line_reader, node, buffer, is_native, found_comment
 
 def process_function_string(node, func, is_native) :
     """process_function_string(string, string, bool)"""
-    if re.search(r'deprecated', func) :
-        return
 
     returntype = ''
     split = func.split(' ', 1)

--- a/SPCompletions.py
+++ b/SPCompletions.py
@@ -379,7 +379,6 @@ def process_lines(line_reader, node) :
         (buffer, found_comment, brace_level) = read_string(buffer, found_comment, brace_level)
         if len(buffer) <= 0 :
             continue
-
         if buffer.startswith('#pragma deprecated') :
             buffer = read_line(line_reader)
             if buffer is not None and buffer.startswith('stock ') :
@@ -531,7 +530,7 @@ def get_full_function_string(line_reader, node, buffer, is_native, found_comment
 
 def process_function_string(node, func, is_native) :
     """process_function_string(string, string, bool)"""
-
+    returntype = ''
     split = func.split(' ', 1)
     if len(split) < 2 :
         functype = ''
@@ -539,6 +538,11 @@ def process_function_string(node, func, is_native) :
     else :
         functype = split[0].strip()
         remaining = split[1]
+        m = re.search(r'(\w+)[ \t]+(.*?\(.*\n?)', remaining)
+        if m :
+            returntype = m.group(1)
+            remaining = m.group(2)
+
     # TODO: Process functags
     if functype == 'functag' :
         return
@@ -568,7 +572,10 @@ def process_function_string(node, func, is_native) :
         autocomplete += '${%d:%s}' % (i, param.strip())
         i += 1
     autocomplete += ')'
-    node.funcs.add((funcname + '  (function)', autocomplete))
+    if returntype :
+        node.funcs.add((returntype + ' | ' + funcname + '  (function)', autocomplete))
+    else :
+        node.funcs.add((funcname + '  (function)', autocomplete))
 
 def skip_brace_line(line_reader, buffer) :
     """skip_brace_line(File, string) -> string"""

--- a/SPCompletions.py
+++ b/SPCompletions.py
@@ -530,6 +530,9 @@ def get_full_function_string(line_reader, node, buffer, is_native, found_comment
 
 def process_function_string(node, func, is_native) :
     """process_function_string(string, string, bool)"""
+    if re.search(r'deprecated', func) :
+        return
+
     returntype = ''
     split = func.split(' ', 1)
     if len(split) < 2 :
@@ -538,7 +541,7 @@ def process_function_string(node, func, is_native) :
     else :
         functype = split[0].strip()
         remaining = split[1]
-        m = re.search(r'([^ ]+)[ \t]+([^ ]+\(.*\n?)', remaining)
+        m = re.search(r'([^\s]+)[ \t]+([^\s]+\(.*\n?)', remaining)
         if m :
             returntype = m.group(1)
             remaining = m.group(2)
@@ -573,7 +576,7 @@ def process_function_string(node, func, is_native) :
         i += 1
     autocomplete += ')'
     if returntype :
-        node.funcs.add((returntype + ' | ' + funcname + '  (function)', autocomplete))
+        node.funcs.add((returntype + ' | ' + funcname + ' (function)', autocomplete))
     else :
         node.funcs.add((funcname + ' (function)', autocomplete))
 

--- a/SPCompletions.py
+++ b/SPCompletions.py
@@ -538,7 +538,7 @@ def process_function_string(node, func, is_native) :
     else :
         functype = split[0].strip()
         remaining = split[1]
-        m = re.search(r'(\w+)[ \t]+(.*?\(.*\n?)', remaining)
+        m = re.search(r'([^ ]+)[ \t]+([^ ]+\(.*\n?)', remaining)
         if m :
             returntype = m.group(1)
             remaining = m.group(2)

--- a/SPCompletions.py
+++ b/SPCompletions.py
@@ -575,7 +575,7 @@ def process_function_string(node, func, is_native) :
     if returntype :
         node.funcs.add((returntype + ' | ' + funcname + '  (function)', autocomplete))
     else :
-        node.funcs.add((funcname + '  (function)', autocomplete))
+        node.funcs.add((funcname + ' (function)', autocomplete))
 
 def skip_brace_line(line_reader, buffer) :
     """skip_brace_line(File, string) -> string"""


### PR DESCRIPTION
I've updated the returntype for the autocompletion menu to support new syntax declarations that don't use `type:var` tagging.

Your current version pastes in both the return type and the function. This update adds the return type to the menu and doesn't paste it in

Example:
https://i.imgur.com/aWAFWMT.png